### PR TITLE
Fix generation of relative asset paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "start": "rimraf dist && parcel serve",
-    "build": "rimraf docs .parcel-cache && parcel build --no-source-maps"
+    "build": "rimraf docs .parcel-cache && parcel build --public-url ./ --no-source-maps"
   },
   "devDependencies": {
     "@parcel/core": "^2.9.2",


### PR DESCRIPTION
fixes

It changes 
`<script src="/index.12e005a5.js" nomodule="" `defer=""></script>`

to 
`<script src="index.12e005a5.js" nomodule="" `defer=""></script>`
and fixes issue  https://github.com/plbstl/icon-previewer/issues/1 with github pages as problem was due to resource hosted in "/icon-previewer/index.12e005a5.js" and not "/index.12e005a5.js"